### PR TITLE
Fixing a typo

### DIFF
--- a/pymmonit/__init__.py
+++ b/pymmonit/__init__.py
@@ -123,7 +123,7 @@ class MMonit(object):
         params = dict(id=hostid)
         return self._get('/admin/hosts/get', params).json()
 
-    def admin_hosts_upadte(self, hostid, **kwargs):
+    def admin_hosts_update(self, hostid, **kwargs):
         return NotImplemented
 
     def admin_hosts_delete(self, hostid):


### PR DESCRIPTION
Fixing a typo in the admin_hosts_update method name.